### PR TITLE
Avatar Zombies, EarthBlast change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ Temporary Items
 *.class
 bin/plugin.yml
 .project
+/bin/

--- a/src/com/jedk1/projectkorra/mobs/MobMethods.java
+++ b/src/com/jedk1/projectkorra/mobs/MobMethods.java
@@ -1,10 +1,13 @@
 package com.jedk1.projectkorra.mobs;
 
+import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.earthbending.EarthMethods;
 
 import org.bukkit.World;
 import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.metadata.FixedMetadataValue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -12,8 +15,21 @@ import java.util.List;
 
 public class MobMethods {
 	
+	private static boolean avatar = ProjectKorraMobs.plugin.getConfig().getBoolean("Properties.Avatar.Enabled");
+	
 	public static List<String> disabledWorlds = new ArrayList<String>();
 
+	public static void assignElement(Entity entity) {
+		int i;
+		if (avatar) {
+			i = GeneralMethods.rand.nextInt(5);
+		} else {
+			i = GeneralMethods.rand.nextInt(4);
+		}
+		if (!entity.hasMetadata("element"))
+			entity.setMetadata("element", new FixedMetadataValue(ProjectKorra.plugin, i));
+	}
+	
 	@SuppressWarnings("deprecation")
 	public static boolean isTransparent(Block block) {
 		if (!Arrays.asList(EarthMethods.transparentToEarthbending).contains(block.getTypeId())) {

--- a/src/com/jedk1/projectkorra/mobs/ability/EarthBlast.java
+++ b/src/com/jedk1/projectkorra/mobs/ability/EarthBlast.java
@@ -41,7 +41,7 @@ public class EarthBlast {
 	@SuppressWarnings("deprecation")
 	public EarthBlast(LivingEntity entity, Location target) {
 		this.entity = entity;
-		origin = entity.getLocation().getBlock().getRelative(BlockFace.DOWN).getLocation().getBlock().getRelative(GeneralMethods.getCardinalDirection(entity.getLocation().getDirection())).getLocation();
+		origin = entity.getLocation().getBlock().getRelative(BlockFace.DOWN).getLocation().getBlock().getRelative(GeneralMethods.getCardinalDirection(entity.getLocation().getDirection())).getLocation().add(0.5, 0, 0.5);
 		if (!EarthMethods.isEarthbendable(origin.getBlock().getType())) {
 			return;
 		}

--- a/src/com/jedk1/projectkorra/mobs/listener/MobListener.java
+++ b/src/com/jedk1/projectkorra/mobs/listener/MobListener.java
@@ -3,7 +3,6 @@ package com.jedk1.projectkorra.mobs.listener;
 import com.jedk1.projectkorra.mobs.MobMethods;
 import com.jedk1.projectkorra.mobs.ProjectKorraMobs;
 import com.jedk1.projectkorra.mobs.manager.EntityManager;
-import com.projectkorra.projectkorra.GeneralMethods;
 
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Zombie;
@@ -14,7 +13,6 @@ import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.event.entity.EntityTargetEvent;
-import org.bukkit.metadata.FixedMetadataValue;
 
 public class MobListener implements Listener {
 
@@ -46,9 +44,7 @@ public class MobListener implements Listener {
 			return;
 		}
 		if (entity instanceof Zombie) {
-			if (!entity.hasMetadata("element")) {
-				entity.setMetadata("element", new FixedMetadataValue(ProjectKorraMobs.plugin, GeneralMethods.rand.nextInt(4)));
-			}
+			MobMethods.assignElement(entity);
 		}
 	}
 	
@@ -57,7 +53,7 @@ public class MobListener implements Listener {
 		if (event.getEntity() instanceof LivingEntity) {
 			LivingEntity entity = (LivingEntity) event.getEntity();
 			if (entity instanceof Zombie) {
-				if (entity.hasMetadata("element") && entity.getMetadata("element").size() > 0 && entity.getMetadata("element").get(0).asInt() == 0 && airFallDamage) {
+				if (entity.hasMetadata("element") && entity.getMetadata("element").size() > 0 && (entity.getMetadata("element").get(0).asInt() == 0 || entity.getMetadata("element").get(0).asInt() == 4)  && airFallDamage) {
 					if (event.getCause() == DamageCause.FALL) {
 						event.setCancelled(true);
 						return;

--- a/src/com/jedk1/projectkorra/mobs/manager/ConfigManager.java
+++ b/src/com/jedk1/projectkorra/mobs/manager/ConfigManager.java
@@ -21,6 +21,7 @@ public class ConfigManager {
 
 		config.addDefault("Properties.BendFrequency", 150);
 		config.addDefault("Properties.Air.NoFallDamage", true);
+		config.addDefault("Properties.Avatar.Enabled", true);
 		
 		config.addDefault("Abilities.Air.Enabled", true);
 		config.addDefault("Abilities.Air.AirBlast.Knockback", 1.0);

--- a/src/com/jedk1/projectkorra/mobs/manager/EntityManager.java
+++ b/src/com/jedk1/projectkorra/mobs/manager/EntityManager.java
@@ -12,7 +12,6 @@ import com.projectkorra.projectkorra.waterbending.Bloodbending;
 
 import org.bukkit.entity.Creature;
 import org.bukkit.entity.LivingEntity;
-import org.bukkit.metadata.FixedMetadataValue;
 
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -39,9 +38,7 @@ public class EntityManager {
 			return;
 		}
 		entityarray.put(entity, target);
-		if (!entity.hasMetadata("element")) {
-			entity.setMetadata("element", new FixedMetadataValue(ProjectKorraMobs.plugin, GeneralMethods.rand.nextInt(4)));
-		}
+		MobMethods.assignElement(entity);
 	}
 
 	public static void removeEntity(LivingEntity entity) {
@@ -84,10 +81,32 @@ public class EntityManager {
 									break;
 							}
 							break;
-						default:
-							if (!fire) break;
-							new FireBlast(entity, target.getLocation());
-							break;
+						case 4:
+							switch (GeneralMethods.rand.nextInt(4)) {
+								case 0:
+									if (!air) break;
+									new AirBlast(entity, target.getLocation());
+									break;
+								case 1:
+									if (!earth) break;
+									new EarthBlast(entity, target.getLocation());
+									break;
+								case 2:
+									if (!water) break;
+									new WaterBlast(entity, target.getLocation());
+									break;
+								case 3:
+									if (!fire) break;
+									switch (GeneralMethods.rand.nextInt(2)) {
+										case 0:
+											new FireBlast(entity, target.getLocation());
+											break;
+										case 1:
+											new FireJet(entity, target.getLocation());
+											break;
+									}
+									break;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
- Adds option for zombies to be avatar
- Adds config option for avatar being enabled
- Adds assignElement methods to MobMethods, checks for avatar enabled then assigns the element.
- Made earthblast a little more accurate (you could stand still in some situations and not be hit because the direction was off)